### PR TITLE
Cosmetic changes for pep8.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import absolute_import
 import io
 import os
 import re

--- a/src/datera/datera_api21.py
+++ b/src/datera/datera_api21.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from __future__ import absolute_import
 import contextlib
 import math
 import random
@@ -982,7 +983,7 @@ class DateraApi(object):
             fpolicies = {k: int(v) for k, v in
                          policies.items() if k.endswith("max")}
             # Filter all 0 values from being passed
-            fpolicies = dict(filter(lambda _v: _v[1] > 0, fpolicies.items()))
+            fpolicies = dict([_v for _v in list(fpolicies.items()) if _v[1] > 0])
             # Calculate and set iops/gb and bw/gb, but only if they don't
             # exceed total_iops_max and total_bw_max aren't set since they take
             # priority

--- a/src/datera/datera_api21.py
+++ b/src/datera/datera_api21.py
@@ -32,8 +32,8 @@ from oslo_utils import units
 from cinder import exception
 from cinder.i18n import _
 from cinder.image import image_utils
-from cinder.volume import utils as volutils
 from cinder import utils
+from cinder.volume import utils as volutils
 from cinder.volume import volume_types
 
 from os_brick import exception as brick_exception
@@ -578,7 +578,7 @@ class DateraApi(object):
                 'reference': reference,
                 'size': size,
                 'safe_to_manage': safe_to_manage,
-                'reason_not_safe': _(reason_not_safe),
+                'reason_not_safe': reason_not_safe,
                 'cinder_id': cinder_id,
                 'extra_info': extra_info})
         return results
@@ -880,8 +880,8 @@ class DateraApi(object):
                 except brick_exception.FailedISCSITargetPortalLogin:
                     retries -= 1
                     if not retries:
-                        LOG.error(_("Could not log into portal before end of "
-                                    "polling period"))
+                        LOG.error("Could not log into portal before end of "
+                                  "polling period")
                         raise
                     LOG.debug("Failed to login to portal, retrying")
                     eventlet.sleep(2)
@@ -1035,8 +1035,10 @@ class DateraApi(object):
 
     def _update_migrated_volume_2_1(self, context, volume, new_volume,
                                     volume_status):
-        """Rename the newly created volume to the original volume so we
-           can find it correctly"""
+        """Rename the newly created volume to the original volume.
+
+        So we can find it correctly.
+        """
         tenant = self.get_tenant(new_volume['project_id'])
         ai = self.cvol_to_ai(new_volume, tenant=tenant)
         data = {'name': datc.get_name(volume)}

--- a/src/datera/datera_api21.py
+++ b/src/datera/datera_api21.py
@@ -983,7 +983,8 @@ class DateraApi(object):
             fpolicies = {k: int(v) for k, v in
                          policies.items() if k.endswith("max")}
             # Filter all 0 values from being passed
-            fpolicies = dict([_v for _v in list(fpolicies.items()) if _v[1] > 0])
+            fpolicies = {k: int(v) for k, v in
+                         fpolicies.items() if v > 0}
             # Calculate and set iops/gb and bw/gb, but only if they don't
             # exceed total_iops_max and total_bw_max aren't set since they take
             # priority

--- a/src/datera/datera_api22.py
+++ b/src/datera/datera_api22.py
@@ -1036,7 +1036,8 @@ class DateraApi(object):
             fpolicies = {k: int(v) for k, v in
                          policies.items() if k.endswith("max")}
             # Filter all 0 values from being passed
-            fpolicies = dict([_v for _v in list(fpolicies.items()) if _v[1] > 0])
+            fpolicies = {k: int(v) for k, v in
+                         fpolicies.items() if v > 0}
             # Calculate and set iops/gb and bw/gb, but only if they don't
             # exceed total_iops_max and total_bw_max aren't set since they take
             # priority

--- a/src/datera/datera_api22.py
+++ b/src/datera/datera_api22.py
@@ -32,8 +32,8 @@ from oslo_utils import units
 from cinder import exception
 from cinder.i18n import _
 from cinder.image import image_utils
-from cinder.volume import utils as volutils
 from cinder import utils
+from cinder.volume import utils as volutils
 from cinder.volume import volume_types
 
 from os_brick import exception as brick_exception
@@ -124,10 +124,10 @@ class DateraApi(object):
     def _extend_volume_2_2(self, volume, new_size):
         if volume['size'] >= new_size:
             LOG.warning("Volume size not extended due to original size being "
-                        "greater or equal to new size.  Originial: "
-                        "%(original)s, New: %(new)s", {
-                            'original': volume['size'],
-                            'new': new_size})
+                        "greater or equal to new size. Original: "
+                        "%(original)s, New: %(new)s",
+                        {'original': volume['size'],
+                         'new': new_size})
             return
         policies = self._get_policies_for_resource(volume)
         template = policies['template']
@@ -617,7 +617,7 @@ class DateraApi(object):
                 'reference': reference,
                 'size': size,
                 'safe_to_manage': safe_to_manage,
-                'reason_not_safe': _(reason_not_safe),
+                'reason_not_safe': reason_not_safe,
                 'cinder_id': cinder_id,
                 'extra_info': extra_info})
         return results
@@ -919,8 +919,8 @@ class DateraApi(object):
                 except brick_exception.FailedISCSITargetPortalLogin:
                     retries -= 1
                     if not retries:
-                        LOG.error(_("Could not log into portal before end of "
-                                    "polling period"))
+                        LOG.error("Could not log into portal before end of "
+                                  "polling period")
                         raise
                     LOG.debug("Failed to login to portal, retrying")
                     eventlet.sleep(2)
@@ -1088,8 +1088,10 @@ class DateraApi(object):
 
     def _update_migrated_volume_2_2(self, context, volume, new_volume,
                                     volume_status):
-        """Rename the newly created volume to the original volume so we
-           can find it correctly"""
+        """Rename the newly created volume to the original volume.
+
+        So we can find it correctly.
+        """
         tenant = self.get_tenant(new_volume['project_id'])
         ai = self.cvol_to_ai(new_volume, tenant=tenant)
         data = {'name': datc.get_name(volume)}

--- a/src/datera/datera_api22.py
+++ b/src/datera/datera_api22.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from __future__ import absolute_import
 import contextlib
 import math
 import random
@@ -1035,7 +1036,7 @@ class DateraApi(object):
             fpolicies = {k: int(v) for k, v in
                          policies.items() if k.endswith("max")}
             # Filter all 0 values from being passed
-            fpolicies = dict(filter(lambda _v: _v[1] > 0, fpolicies.items()))
+            fpolicies = dict([_v for _v in list(fpolicies.items()) if _v[1] > 0])
             # Calculate and set iops/gb and bw/gb, but only if they don't
             # exceed total_iops_max and total_bw_max aren't set since they take
             # priority

--- a/src/datera/datera_common.py
+++ b/src/datera/datera_common.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from __future__ import absolute_import
 import functools
 import random
 import re
@@ -355,7 +356,7 @@ def register_driver(driver):
 
         f = types.MethodType(func, driver)
         try:
-            setattr(driver, func.func_name, f)
+            setattr(driver, func.__name__, f)
         # PY3+
         except AttributeError:
             setattr(driver, func.__name__, f)

--- a/src/datera/datera_common.py
+++ b/src/datera/datera_common.py
@@ -231,9 +231,9 @@ def _image_accessible(driver, context, volume, image_meta):
                                                controller='image_members',
                                                image_id=image_meta['id'])
             except glance_exc.HTTPForbidden as e:
-                LOG.warn(e)
+                LOG.warning(e)
         except glance_exc.HTTPForbidden as e:
-            LOG.warn(e)
+            LOG.warning(e)
         members = list(members)
         LOG.debug("Shared image %(image)s members: %(members)s",
                   {"image": image_meta['id'], "members": members})

--- a/src/datera/datera_common.py
+++ b/src/datera/datera_common.py
@@ -86,7 +86,7 @@ def lookup(func):
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         obj = args[0]
-        name = "_" + func.func_name + "_" + obj.apiv.replace(".", "_")
+        name = "_" + func.__name__ + "_" + obj.apiv.replace(".", "_")
         LOG.debug("Trying method: %s", name)
         call_id = uuid.uuid4()
         if obj.do_profile:

--- a/src/datera/datera_iscsi.py
+++ b/src/datera/datera_iscsi.py
@@ -17,10 +17,11 @@ import time
 import uuid
 
 import dfs_sdk
+import six
+
 from eventlet.green import threading
 from oslo_config import cfg
 from oslo_log import log as logging
-import six
 
 from cinder import exception
 from cinder.i18n import _
@@ -506,6 +507,7 @@ class DateraDriver(san.SanISCSIDriver, api21.DateraApi, api22.DateraApi):
     def update_migrated_volume(self, context, volume, new_volume,
                                volume_status):
         """Return model update for migrated volume.
+
         Each driver implementing this method needs to be responsible for the
         values of _name_id and provider_location. If None is returned or either
         key is not set, it means the volume table does not need to change the

--- a/src/datera/datera_iscsi.py
+++ b/src/datera/datera_iscsi.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from __future__ import absolute_import
 import time
 import uuid
 

--- a/src/datera/test_datera.py
+++ b/src/datera/test_datera.py
@@ -18,8 +18,8 @@ import sys
 import uuid
 
 from cinder import context
-from cinder import test
 from cinder import exception
+from cinder import test
 from cinder.volume import configuration as conf
 from cinder.volume import volume_types
 
@@ -84,7 +84,7 @@ class DateraVolumeTestCasev22(test.TestCase):
     def test_volume_create_fails(self):
         testvol = _stub_volume()
         self.driver.api.app_instances.create.side_effect = (
-                exception.DateraAPIException)
+            exception.DateraAPIException)
         self.assertRaises(exception.DateraAPIException,
                           self.driver.create_volume,
                           testvol)
@@ -92,25 +92,25 @@ class DateraVolumeTestCasev22(test.TestCase):
     @mock.patch.object(volume_types, 'get_volume_type')
     def test_create_volume_with_extra_specs(self, mock_get_type):
         mock_get_type.return_value = {
-             'name': u'The Best',
-             'qos_specs_id': None,
-             'deleted': False,
-             'created_at': '2015-08-14 04:18:11',
-             'updated_at': None,
-             'extra_specs': {
-                 u'volume_backend_name': u'datera',
-                 u'qos:max_iops_read': u'2000',
-                 u'qos:max_iops_write': u'4000',
-                 u'qos:max_iops_total': u'4000'
-             },
-             'is_public': True,
-             'deleted_at': None,
-             'id': u'dffb4a83-b8fb-4c19-9f8c-713bb75db3b1',
-             'description': None
-         }
+            'name': u'The Best',
+            'qos_specs_id': None,
+            'deleted': False,
+            'created_at': '2015-08-14 04:18:11',
+            'updated_at': None,
+            'extra_specs': {
+                u'volume_backend_name': u'datera',
+                u'qos:max_iops_read': u'2000',
+                u'qos:max_iops_write': u'4000',
+                u'qos:max_iops_total': u'4000'
+            },
+            'is_public': True,
+            'deleted_at': None,
+            'id': u'dffb4a83-b8fb-4c19-9f8c-713bb75db3b1',
+            'description': None
+        }
 
         mock_volume = _stub_volume(
-             volume_type_id='dffb4a83-b8fb-4c19-9f8c-713bb75db3b1'
+            volume_type_id='dffb4a83-b8fb-4c19-9f8c-713bb75db3b1'
         )
 
         self.assertIsNone(self.driver.create_volume(mock_volume))
@@ -135,7 +135,7 @@ class DateraVolumeTestCasev22(test.TestCase):
         testvol = _stub_volume()
         ref = _stub_volume(id=str(uuid.uuid4()))
         self.driver.api.app_instances.create.side_effect = (
-                exception.DateraAPIException)
+            exception.DateraAPIException)
         self.assertRaises(exception.DateraAPIException,
                           self.driver.create_cloned_volume,
                           testvol,
@@ -154,7 +154,7 @@ class DateraVolumeTestCasev22(test.TestCase):
     def test_delete_volume_fails(self):
         testvol = _stub_volume()
         self.driver.api.app_instances.list.side_effect = (
-                exception.DateraAPIException)
+            exception.DateraAPIException)
         self.assertRaises(exception.DateraAPIException,
                           self.driver.delete_volume, testvol)
 
@@ -186,7 +186,7 @@ class DateraVolumeTestCasev22(test.TestCase):
         simock = mock.MagicMock()
         simock.reload.return_value = simock
         aimock.storage_instances.list.side_effect = (
-                exception.DateraAPIException)
+            exception.DateraAPIException)
         simock.op_state = "available"
         self.driver.cvol_to_ai = mock.Mock()
         self.driver.cvol_to_ai.return_value = aimock
@@ -221,7 +221,7 @@ class DateraVolumeTestCasev22(test.TestCase):
         simock.access = {"ips": ["test-ip"], "iqn": "test-iqn"}
         simock.reload.return_value = simock
         aimock.storage_instances.list.side_effect = (
-                exception.DateraAPIException)
+            exception.DateraAPIException)
         self.driver.cvol_to_ai = mock.Mock()
         self.driver.cvol_to_ai.return_value = aimock
         self.assertRaises(exception.DateraAPIException,
@@ -273,7 +273,7 @@ class DateraVolumeTestCasev22(test.TestCase):
     def test_create_snapshot_fails(self):
         testsnap = _stub_snapshot(volume_id=str(uuid.uuid4()))
         self.driver.api.app_instances.list.side_effect = (
-                exception.DateraAPIException)
+            exception.DateraAPIException)
         self.assertRaises(exception.DateraAPIException,
                           self.driver.create_snapshot,
                           testsnap)

--- a/src/datera/test_datera.py
+++ b/src/datera/test_datera.py
@@ -76,6 +76,7 @@ class DateraVolumeTestCasev22(test.TestCase):
         # No-op config getter
         self.driver.configuration.get = lambda *args, **kwargs: {}
         # self.addCleanup(self.api_patcher.stop)
+        self.driver.datera_version = "3.3.3"
 
     def test_volume_create_success(self):
         testvol = _stub_volume()

--- a/src/datera/test_datera.py
+++ b/src/datera/test_datera.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+from __future__ import absolute_import
 import mock
 import sys
 import uuid


### PR DESCRIPTION
Cosmetic changes to make pep8 happy. Addressing the following issues:

./cinder/volume/drivers/datera/datera_api21.py:36:1: H306  imports not in alphabetical order (cinder.volume.utils, cinder.utils)
./cinder/volume/drivers/datera/datera_api21.py:581:38: H701  Empty localization string
./cinder/volume/drivers/datera/datera_api21.py:883:25: C312  Log messages should not be translated!
./cinder/volume/drivers/datera/datera_api21.py:1039:1: H405  multi line docstring summary not separated with an empty line
./cinder/volume/drivers/datera/datera_api21.py:1039:33: H403  multi line docstrings should end on a new line
./cinder/volume/drivers/datera/datera_api22.py:36:1: H306  imports not in alphabetical order (cinder.volume.utils, cinder.utils)
./cinder/volume/drivers/datera/datera_api22.py:620:38: H701  Empty localization string
./cinder/volume/drivers/datera/datera_api22.py:922:25: C312  Log messages should not be translated!
./cinder/volume/drivers/datera/datera_api22.py:1092:1: H405  multi line docstring summary not separated with an empty line
./cinder/volume/drivers/datera/datera_api22.py:1092:33: H403  multi line docstrings should end on a new line
./cinder/volume/drivers/datera/datera_common.py:234:17: C307  LOG.warn is deprecated, please use LOG.warning!
./cinder/volume/drivers/datera/datera_common.py:236:13: C307  LOG.warn is deprecated, please use LOG.warning!
./cinder/volume/drivers/datera/datera_iscsi.py:519:1: H405  multi line docstring summary not separated with an empty line
./cinder/volume/drivers/datera/test_datera.py:22:1: H306  imports not in alphabetical order (cinder.test, cinder.exception)
./cinder/volume/drivers/datera/test_datera.py:87:17: E126 continuation line over-indented for hanging indent
./cinder/volume/drivers/datera/test_datera.py:95:14: E126 continuation line over-indented for hanging indent
./cinder/volume/drivers/datera/test_datera.py:110:10: E121 continuation line under-indented for hanging indent
./cinder/volume/drivers/datera/test_datera.py:113:14: E126 continuation line over-indented for hanging indent
./cinder/volume/drivers/datera/test_datera.py:138:17: E126 continuation line over-indented for hanging indent
./cinder/volume/drivers/datera/test_datera.py:157:17: E126 continuation line over-indented for hanging indent
./cinder/volume/drivers/datera/test_datera.py:189:17: E126 continuation line over-indented for hanging indent
./cinder/volume/drivers/datera/test_datera.py:224:17: E126 continuation line over-indented for hanging indent
./cinder/volume/drivers/datera/test_datera.py:276:17: E126 continuation line over-indented for hanging indent
./cinder/volume/drivers/datera/backup/datera.py:40:1: H306  imports not in alphabetical order (six, shlex)
./cinder/volume/drivers/datera/backup/datera.py:52:32: H301  one import per line
./cinder/volume/drivers/datera/backup/datera.py:57:1: H306  imports not in alphabetical order (cinder.interface, cinder.i18n._)
./cinder/volume/drivers/datera/backup/datera.py:233:17: C312  Log messages should not be translated!
./cinder/volume/drivers/datera/backup/datera.py:295:13: C312  Log messages should not be translated!
./cinder/volume/drivers/datera/backup/datera.py:328:9: C312  Log messages should not be translated!
./cinder/volume/drivers/datera/backup/datera.py:350:9: C312  Log messages should not be translated!
./cinder/volume/drivers/datera/backup/datera.py:391:60: E126 continuation line over-indented for hanging indent
./cinder/volume/drivers/datera/backup/datera.py:477:25: C312  Log messages should not be translated!
./cinder/volume/drivers/datera/backup/datera.py:660:1: H405  multi line docstring summary not separated with an empty line
./cinder/volume/drivers/datera/backup/datera.py:686:9: C312  Log messages should not be translated!
./cinder/volume/drivers/datera/backup/datera.py:686:9: H904  String interpolation should be delayed to be handled by the logging code, rather than being done at the point of the logging call. Use ',' instead of '%'.
./cinder/volume/drivers/datera/backup/datera.py:687:21: H702  Formatting operation should be outside of localization method call
./cinder/volume/drivers/datera/backup/datera.py:709:9: C312  Log messages should not be translated!
./cinder/volume/drivers/datera/backup/datera.py:709:9: H904  String interpolation should be delayed to be handled by the logging code, rather than being done at the point of the logging call. Use ',' instead of '%'.
./cinder/volume/drivers/datera/backup/datera.py:709:70: H702  Formatting operation should be outside of localization method call
./cinder/volume/drivers/datera/backup/datera.py:725:13: C312  Log messages should not be translated!
./cinder/volume/drivers/datera/backup/datera.py:725:13: H904  String interpolation should be delayed to be handled by the logging code, rather than being done at the point of the logging call. Use ',' instead of '%'.
./cinder/volume/drivers/datera/backup/datera.py:728:35: H702  Formatting operation should be outside of localization method call
./cinder/volume/drivers/datera/backup/datera.py:753:9: C312  Log messages should not be translated!
./cinder/volume/drivers/datera/backup/datera.py:753:9: H904  String interpolation should be delayed to be handled by the logging code, rather than being done at the point of the logging call. Use ',' instead of '%'.
./cinder/volume/drivers/datera/backup/datera.py:754:21: H702  Formatting operation should be outside of localization method call
./cinder/volume/drivers/datera/backup/datera.py:771:9: C312  Log messages should not be translated!
./cinder/volume/drivers/datera/backup/datera.py:771:9: H904  String interpolation should be delayed to be handled by the logging code, rather than being done at the point of the logging call. Use ',' instead of '%'.
./cinder/volume/drivers/datera/backup/datera.py:771:70: H702  Formatting operation should be outside of localization method call
./cinder/volume/drivers/datera/backup/datera.py:782:9: C312  Log messages should not be translated!
./cinder/volume/drivers/datera/backup/datera.py:792:13: C312  Log messages should not be translated!
./cinder/volume/drivers/datera/backup/datera.py:792:13: H904  String interpolation should be delayed to be handled by the logging code, rather than being done at the point of the logging call. Use ',' instead of '%'.
./cinder/volume/drivers/datera/backup/datera.py:795:35: H702  Formatting operation should be outside of localization method call
./cinder/volume/drivers/datera/backup/datera.py:804:58: H702  Formatting operation should be outside of localization method call
