### PR TITLE
Cleaning up the tempest test run.

### DIFF
--- a/scripts/ci/devstack_up.py
+++ b/scripts/ci/devstack_up.py
@@ -20,6 +20,7 @@ from __future__ import unicode_literals, print_function, division
 
 import argparse
 import sys
+import subprocess
 import time
 
 try:
@@ -37,9 +38,10 @@ except NameError:
 
 SUCCESS = 0
 FAILURE = 1
-REBOOT_WAIT = 30 * 60
-DEVSTACK_WAIT = 300
-TEMPEST_WAIT = 300
+WAIT_TIME = 60
+REBOOT_WAIT = 60 * 60
+DEVSTACK_WAIT = 3600
+TEMPEST_WAIT = 3600
 INITIAL_SSH_TIMEOUT = 600
 DAT_CINDER_URL = "http://github.com/Datera/cinder-driver"
 DAT_GLANCE_URL = "http://github.com/Datera/glance-driver"
@@ -95,6 +97,9 @@ CINDER_BRANCH={patchset}
 [DEFAULT]
 iscsi_target_prefix=iqn:
 CINDER_ENABLED_BACKENDS=datera
+default_volume_type = datera
+enabled_backends = datera
+
 [datera]
 volume_driver=cinder.volume.drivers.datera.datera_iscsi.DateraDriver
 san_is_local=True
@@ -106,19 +111,18 @@ volume_backend_name=datera
 datera_debug_replica_count_override=True
 """
 
-
 class SSH(object):
     def __init__(self, ip, username, password, keyfile=None):
         self.ip = ip
         self.username = username
         self.password = password
         self.keyfile = keyfile
+        # print(self.ip, self.username, self.password, self.keyfile)
 
         self.ssh = paramiko.SSHClient()
         self.ssh.set_missing_host_key_policy(
             paramiko.AutoAddPolicy())
         # Normal username/password usage
-        print(self.ip, self.username, self.password, self.keyfile)
         self.ssh.connect(
             hostname=self.ip,
             username=self.username,
@@ -134,15 +138,19 @@ class SSH(object):
             key_filename=self.keyfile,
             banner_timeout=timeout)
 
-    def exec_command(self, command, fail_ok=False):
+    def exec_command(self, command, fail_ok=False, wait=True, quiet=False):
         s = self.ssh
-        msg = "Executing command: {} on VM: {}".format(command, self.ip)
-        print(msg)
+        if not quiet:
+            msg = "Executing command: {} on VM: {}".format(command, self.ip)
+            print(msg)
         _, stdout, stderr = s.exec_command(command)
         exit_status = stdout.channel.recv_exit_status()
         result = None
         if int(exit_status) == 0:
-            result = stdout.read()
+            if wait:
+                result = stdout.read()
+            else:
+                return result
         elif fail_ok:
             result = stderr.read()
         else:
@@ -152,6 +160,18 @@ class SSH(object):
                     stderr.read()))
         return result.decode('utf-8')
 
+def setup_interfaces(ssh):
+    cmd = "ip link set dev eth3 up"
+    ssh.exec_command(cmd)
+
+    cmd = "ip addr add 172.28.41.8/24 dev eth3"
+    ssh.exec_command(cmd, fail_ok=True)
+
+    cmd = "ip link set dev eth2 up"
+    ssh.exec_command(cmd)
+
+    cmd = "ip addr add 172.29.41.8/24 dev eth2"
+    ssh.exec_command(cmd, fail_ok=True)
 
 def setup_stack_user(ssh):
     cmd = ""
@@ -160,6 +180,9 @@ def setup_stack_user(ssh):
         cmd = "yum install git python-setuptools -y"
     except EnvironmentError:
         cmd = "apt-get install git -y"
+    ssh.exec_command(cmd)
+
+    cmd = "rm -rf devstack"
     ssh.exec_command(cmd)
 
     cmd = "git clone http://github.com/openstack-dev/devstack"
@@ -175,8 +198,12 @@ def setup_stack_user(ssh):
     stdin.write('stack\n')
     stdin.write('stack\n')
 
-
 def install_devstack(ssh, cluster_ip, tenant, patchset, version):
+    print("Installing Devstack...")
+
+    cmd = "rm -rf devstack"
+    ssh.exec_command(cmd)
+
     cmd = "git clone http://github.com/openstack-dev/devstack"
     ssh.exec_command(cmd)
     lcnf = LOCALCONF.format(
@@ -199,31 +226,32 @@ def _unstack(ssh):
 
 def _install_devstack(ssh, version):
     if version != "master":
-        cmd = ("cd devstack && git checkout {} && ./stack.sh >/dev/null "
+        cmd = ("cd devstack && git checkout {} && nohup ./stack.sh >/dev/null "
                "2>&1 &".format(version))
     else:
-        cmd = "cd devstack && ./stack.sh >/dev/null 2>&1 &"
-    ssh.exec_command(cmd)
+        cmd = "cd devstack && nohup ./stack.sh >/dev/null 2>&1 &"
+    ssh.exec_command(cmd, wait=False)
 
     count = 0
-    increment = 10
     while count <= DEVSTACK_WAIT:
         try:
             ssh.exec_command(
                 ("grep 'This is your host IP address:' "
-                 "/opt/stack/devstacklog.txt"))
+                 "/opt/stack/devstacklog.txt"), quiet=True)
             break
         except EnvironmentError:
             try:
                 # This means python-setuptools needs to be reinstalled again
                 ssh.exec_command(
                     ("grep 'operator not allowed in environment markers' "
-                     "/opt/stack/devstacklog.txt"))
+                     "/opt/stack/devstacklog.txt"), quiet=True)
                 return "SetupTools"
             except EnvironmentError:
                 pass
-            time.sleep(increment)
-            count += increment
+            time.sleep(WAIT_TIME)
+            count += WAIT_TIME
+            print(ssh.exec_command(
+                "tail -1 /opt/stack/devstacklog.txt.summary", quiet=True).strip())
     if count >= DEVSTACK_WAIT:
         raise EnvironmentError("Timeout expired before stack.sh "
                                "completed")
@@ -250,7 +278,12 @@ def _update_drivers(ssh, mgmt_ip, patchset, cinder_version, glance_version):
             cinder_version))
     ssh.exec_command("cd cinder-driver/src/datera && cp *.py {}".format(
         DEV_DRIVER_LOC))
-    ssh.exec_command("sudo service devstack@c-vol restart")
+    cmd = ("cp /opt/stack/cinder-driver/src/datera/test_datera.py "
+        "/opt/stack/cinder/cinder/tests/unit/volume/drivers/test_datera.py")
+    ssh.exec_command(cmd)
+
+    ssh.exec_command("sudo systemctl restart devstack@c-vol.service")
+    ssh.exec_command("sudo systemctl restart devstack@c-sch.service")
 
     # Cause sometimes we just don't need this complexity
     if glance_version == "none":
@@ -300,7 +333,7 @@ datera_replica_count = 1
     # Modify glance filters
     cmd = "cd glance-driver/etc/glance && sudo cp -r * /etc/glance/"
     ssh.exec_command(cmd)
-    ssh.exec_command("sudo service devstack@g-api restart")
+    ssh.exec_command("sudo systemctl restart devstack@g-api.service")
 
 
 def _find_glance_dirs(ssh):
@@ -310,64 +343,60 @@ def _find_glance_dirs(ssh):
     info = ssh.exec_command(cmd).strip()
     return (install, "/".join((info, "entry_points.txt")))
 
-
 def run_tempest(ssh):
     ssh.exec_command("cd /opt/stack/cinder && echo cinder_commit_id "
                      "$(git rev-parse HEAD) > "
                      "/opt/stack/tempest/console.out.log")
     ssh.exec_command("cd /opt/stack/tempest && "
-                     "tox -e all -- volume | tee -a "
-                     "console.out.log 2>/dev/null &")
+                     "tox -e all -- volume "
+                     ">console.out.log 2>/dev/null &", wait = False)
     count = 0
-    increment = 10
     while count <= TEMPEST_WAIT:
         try:
-            result = ssh.exec_command(r"grep -oP ' - Failed: \d+' "
-                                      "/opt/stack/tempest/console.out.log")
+            print("Checking test results ...")
+            result = ssh.exec_command(
+                "grep -oP 'Failed: \d+' /opt/stack/tempest/console.out.log", quiet=True)
             return int(result.split(":")[-1])
             break
         except EnvironmentError:
-            time.sleep(increment)
-            count += increment
-    if count >= DEVSTACK_WAIT:
-        raise EnvironmentError("Timeout expired before tempest "
+            time.sleep(WAIT_TIME)
+            count += WAIT_TIME
+    if count >= TEMPEST_WAIT:
+        raise EnvironmentError("Timeout expired before stack.sh "
                                "completed")
 
-
-def do_reimage_client(ssh):
-    print("Wiping client")
-    cmd = r"yes yes | sudo /root/reinstall.sh"
-    ssh.exec_command(cmd)
+def reinstall_node(ip, username, password):
+    print("Wiping node: {}".format(ip))
+    cmd = "resolveip -s {}".format(ip)
+    print("Executing: {}".format(cmd))
+    host = subprocess.check_output(cmd.split()).rstrip().split('.')[0]
+    if not host:
+        raise ValueError("Couldn't determine hostname from ip: {}".format(ip))
+    cmd = "ipmitool -H {}-ipmi.tlx.daterainc.com -U root -P carnifex -I lanplus chassis bootdev pxe".format(host)
+    print("Executing: {}".format(cmd))
+    subprocess.check_output(cmd.split())
+    cmd = "ipmitool -H {}-ipmi.tlx.daterainc.com -U root -P carnifex -I lanplus chassis power cycle".format(host)
+    print("Executing: {}".format(cmd))
+    subprocess.check_output(cmd.split())
     # Wait for node to reboot
     time.sleep(10)
     # Poll for node availability
     count = 0
-    increment = 20
     while count <= REBOOT_WAIT:
         try:
-            ssh.reconnect(10)
+            ssh = SSH(ip, username, password)
             ssh.exec_command("uname -a")
             print("Wipe complete, node accessible")
-            return ssh
-        except paramiko.ssh_exception.BadHostKeyException:
-            # In this case the remiage completed successfully but we're
-            # getting rejected because the host keys don't match which
-            # we expect.  We'll just reinitialize the ssh object to work
-            # around this.
-            ssh = SSH(ssh.ip, ssh.username, ssh.password)
-            ssh.exec_command("uname -a")
-            print("Wipe complete, node accessible")
-            return ssh
+            break
         except Exception as e:
-            print(e)
+            print("Sleeping, node inaccessible: {}".format(e))
             if count >= REBOOT_WAIT:
                 print(e)
-                raise
-                # raise EnvironmentError(
-                #     "Timeout expired before node became reachable")
-            time.sleep(increment)
-            count += increment
-
+                raise EnvironmentError(
+                    "Timeout expired before node became reachable")
+            time.sleep(WAIT_TIME)
+            count += WAIT_TIME
+    print("Ubuntu node ready...")
 
 def main(node_ip, username, password, cluster_ip, tenant, patchset,
          devstack_version, cinder_driver_version, glance_driver_version,
@@ -382,10 +411,11 @@ def main(node_ip, username, password, cluster_ip, tenant, patchset,
             ssh, cluster_ip, patchset, cinder_driver_version,
             glance_driver_version)
     else:
-        root_ssh = SSH(node_ip, username, password)
         if reimage_client:
-            root_ssh = do_reimage_client(root_ssh)
+            reinstall_node(args.node_ip, args.username, args.password)
+        root_ssh = SSH(args.node_ip, args.username, args.password)
         setup_stack_user(root_ssh)
+        setup_interfaces(root_ssh)
 
         ssh = SSH(node_ip, 'stack', 'stack')
         install_devstack(ssh, cluster_ip, tenant, patchset, devstack_version)
@@ -399,8 +429,7 @@ def main(node_ip, username, password, cluster_ip, tenant, patchset,
             print("Tempest Failed :(, Failures: {}".format(result))
     else:
         print('Devstack setup finished without error')
-    return SUCCESS
-
+    return result
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
- Adding parameters for async SSH execution (was not working)
- Adding parameters to quiet down some output
- Configurable increment step in progress reporting
- Better progress indication on devstack installation
- More reliable system wipe
- More idempotents steps (still not all)
- Setting up interfaces on test setup for access network
- Re-establish SSH sessions instead of relying on long sessions