### PR TITLE
Allow extend on same size.

### DIFF
--- a/src/datera/datera_api21.py
+++ b/src/datera/datera_api21.py
@@ -109,7 +109,7 @@ class DateraApi(object):
     # =================
 
     def _extend_volume_2_1(self, volume, new_size):
-        if volume['size'] >= new_size:
+        if volume['size'] > new_size:
             LOG.warning("Volume size not extended due to original size being "
                         "greater or equal to new size.  Originial: "
                         "%(original)s, New: %(new)s", {

--- a/src/datera/datera_api22.py
+++ b/src/datera/datera_api22.py
@@ -123,7 +123,7 @@ class DateraApi(object):
     # =================
 
     def _extend_volume_2_2(self, volume, new_size):
-        if volume['size'] >= new_size:
+        if volume['size'] > new_size:
             LOG.warning("Volume size not extended due to original size being "
                         "greater or equal to new size. Original: "
                         "%(original)s, New: %(new)s",


### PR DESCRIPTION
The reason for this is that OS decides the size of the volume before
calling the driver and before a potential resize operation comes
to the driver.

In the case of volume create from cache image, the cached image has
the orignial size, but the created volume already has a bigger
(extended) size before the call is made to the driver API.

Thus, the resize operation was blocked by the driver, which was
assuming is a no-op.

With this change, a same size resize is accepted, which solves the
use case above. Even if the Datera API is called with the same size,
the 'resize to the same size' operation is a no op on the Datera
side, so that case is covered as well.