### PR TITLE
Fix volume delete.

### DIFF
--- a/src/datera/datera_api21.py
+++ b/src/datera/datera_api21.py
@@ -156,10 +156,22 @@ class DateraApi(object):
     # =================
 
     def _delete_volume_2_1(self, volume):
-        self._detach_volume_2_1(None, volume)
         try:
             tenant = self.get_tenant(volume['project_id'])
             ai = self.cvol_to_ai(volume, tenant=tenant)
+            si = ai.storage_instances.list(tenant=tenant)[0]
+
+            # Clear out ACL
+            acl = si.acl_policy.get(tenant=tenant)
+            acl.set(tenant=tenant, initiators=[])
+
+            # Bring volume offline
+            data = {
+                'admin_state': 'offline',
+                'force': True
+            }
+            ai.set(tenant=tenant, **data)
+
             ai.delete(tenant=tenant, force=True)
         except exception.NotFound:
             msg = ("Tried to delete volume %s, but it was not found in the "

--- a/src/datera/datera_api22.py
+++ b/src/datera/datera_api22.py
@@ -171,10 +171,22 @@ class DateraApi(object):
     # =================
 
     def _delete_volume_2_2(self, volume):
-        self._detach_volume_2_2(None, volume)
         try:
             tenant = self.get_tenant(volume['project_id'])
             ai = self.cvol_to_ai(volume, tenant=tenant)
+            si = ai.storage_instances.list(tenant=tenant)[0]
+
+            # Clear out ACL
+            acl = si.acl_policy.get(tenant=tenant)
+            acl.set(tenant=tenant, initiators=[])
+
+            # Bring volume offline
+            data = {
+                'admin_state': 'offline',
+                'force': True
+            }
+            ai.set(tenant=tenant, **data)
+
             ai.delete(tenant=tenant, force=True)
         except exception.NotFound:
             msg = ("Tried to delete volume %s, but it was not found in the "


### PR DESCRIPTION
If volume delete is called while a volume is still attached,
the new dettach logic does not allow us to cleanly delete the
volume.

So, instead of reusing dettach, simply clean up the ACLs,
bring the volume offline and then delete it.

Found during tempest tests during nightly run, in particular
tempest.api.volume.test_volumes_actions.
VolumesActionsTest.test_volume_upload
Leaves a volume atached when it calls cleanup (delete).