### PR TITLE
Adding safeguards for non-root tenants.

### DIFF
--- a/src/cinder/volume/drivers/datera/datera_common.py
+++ b/src/cinder/volume/drivers/datera/datera_common.py
@@ -288,6 +288,8 @@ def create_tenant(driver, project_id):
             driver.api.tenants.create(name=name)
         except dfs_sdk.exceptions.ApiConflictError:
             LOG.debug("Tenant {} already exists".format(name))
+        except dfs_sdk.exceptions.ApiError:
+            LOG.debug("Tenant {} cannot be created, make sure it exists".format(name))
     return _format_tenant(name)
 
 


### PR DESCRIPTION
For non-root tenants, the 'create tenant' API fails with either a
422 error ("Error creating tenant, can only create tenants that
are descendants of tenants you administer")
or
401 unauthorized ("Permissions error: you do not have have
permission for this operation.")
depending on the tenant permissions.

This patch cacthes all those cases and instructs the user to
create the tenant manually if such an error occurs.